### PR TITLE
Speaker notes, fragments, quotes, image borders configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ Push headers below slide_level to the next higher one. Boolean:
 The default is false.
 
 
+### Image borders
+
+Show image borders (default in Reveal.js). Boolean:
+
+* false
+* true
+
+The default is false.
+
+
 
 Supported dokuwiki syntax
 -------------------------
@@ -186,6 +196,45 @@ All other options are also overwritable in a wiki page by using the URL query pa
 ~~REVEAL theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=0&open_in_new_window=1~~
 ```
 Please note that boolean values must be numeric (1 or 0). If you want to be able to change the options directly in the URL after the presentation has started, then you have to disable DokuWiki's caching by putting `~~NOCACHE~~` at the top of the page.
+
+
+### Speaker notes
+
+- https://github.com/hakimel/reveal.js#speaker-notes
+- keyword: <notes> (no parameters)
+- No changes on wiki pages
+- On slideshow content is wrapped into <div class="notes"> and invisible (only shown on speaker notes - shortkey s)
+- Lists in notes are always NOT incremental, because the list is unvisible and you would have to press the next key for each entry without any obvious effect
+
+Example:
+```
+<notes>
+- your content
+- here
+</notes>
+```
+
+### Fragments
+
+- https://github.com/hakimel/reveal.js#fragments
+- <fragment> for inline usage (only formatting and substitutions supported)
+- <fragment-block> for any wiki content
+- <fragment-list> to overwrite the global option build_all_lists (if false)
+- <no-fragment-list> to overwrite the global option build_all_lists (if true)
+- support for style and index where possible - see also example_presentation.dokuwiki and http://lab.hakim.se/reveal-js/#/7/1
+
+Example:
+```
+<fragment>Hit the next arrow...</fragment>
+
+<fragment>... to step through ...</fragment>
+
+<fragment>... a</fragment> <fragment>fragmented</fragment> <fragment>slide.</fragment>
+```
+
+
+
+
 
 
 ### Slide background

--- a/conf/default.php
+++ b/conf/default.php
@@ -7,3 +7,4 @@ $conf['show_progress_bar'] = 0;
 $conf['open_in_new_window'] = 1;
 $conf['slide_level'] = 2;
 $conf['push_headers'] = 0;
+$conf['image_borders'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,3 +8,4 @@ $meta['show_progress_bar'] = array('onoff');
 $meta['open_in_new_window'] = array('onoff');
 $meta['slide_level'] = array('multichoice','_choices' => array(1, 2));
 $meta['push_headers'] = array('onoff');
+$meta['image_borders'] = array('onoff');

--- a/doku-substitutes.css
+++ b/doku-substitutes.css
@@ -1,10 +1,19 @@
 /*
 * This substitutes some dokuwiki css styles.
 * All dokuwiki styles are ignored for reveal.js
-* 
+*
 * To obtain some compatibility, some of them are here redefined.
 *
 */
+.reveal sup, .reveal sub {
+    font-size: .75em;
+}
+
+.reveal em.u {
+    font-style: normal;
+    text-decoration: underline;
+}
+
 .medialeft {
   float: left;
 }
@@ -29,12 +38,6 @@
 }
 .reveal h4 {
   margin-top: 20px !important;
-}
-
-.reveal img {
-  border: none !important;
-  box-shadow: none !important;
-  background: none !important;
 }
 
 .reveal dl {
@@ -94,16 +97,16 @@
 
 
 .no-footer .wrap_footer {
-  	visibility: hidden; 
+  	visibility: hidden;
 }
 
 
 .no-footer .wrap_footer_left {
-  	visibility: hidden; 
+  	visibility: hidden;
 }
 
 .no-footer .wrap_footer_right {
-  	visibility: hidden; 
+  	visibility: hidden;
 }
 
 .has-dark-background .white-only {

--- a/example_presentation.dokuwiki
+++ b/example_presentation.dokuwiki
@@ -1,10 +1,23 @@
 ~~NOCACHE~~
-~~REVEAL theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=1&slide_level=2&push_headers=0&open_in_new_window=1~~
+~~REVEAL theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=1&image_borders=0&slide_level=2&push_headers=0&open_in_new_window=1~~
+
 
 
 ====== Revealjs Test ======
 
 This is a test suite for the reval.js plugin.
+
+<notes>
+These are notes. They are only shown on the wiki page.
+
+  * Lists in notes are always NOT incremental
+  * This is because you would have to press for each list entry the next button without seeing anything
+
+<code php>
+echo 'Hello World'; // code block inside notes
+</code>
+</notes>
+
 
 
 ==== Header level test ====
@@ -12,13 +25,18 @@ This is a test suite for the reval.js plugin.
 Test, if an H3 section following an H1 section is appended horizontally or vertically.
 
 
-===== Caching =====
+
+===== Options (Caching) =====
 
 If you disable the cache for the page, then you are able to change the options direct in the URL.
 
 In case your theme does not match the environment for the presentation you can fix this very fast without editing the page.
 
+
+
 ===== List =====
+
+For this page the option ''build_all_lists'' is switched on  - the list is therefore shown incremental:
 
   * Unordered list, item one
   * Another item
@@ -27,10 +45,132 @@ In case your theme does not match the environment for the presentation you can f
   * A third item for testing
 
 
+
+===== Fragments =====
+
+
+==== Fragment (inline) ====
+
+<nowiki><fragment>text</fragment></nowiki>
+
+<fragment>Hit the next arrow...</fragment>
+
+<fragment>... to step through ...</fragment>
+
+<fragment>... a</fragment> <fragment>fragmented</fragment> <fragment>slide.</fragment>
+
+
+
+
+==== Fragment (inline) ====
+
+Inline Fragments supporting only formatting and substitutions:
+
+<fragment>
+DokuWiki supports **bold**, //italic//, __underlined__ and ''monospaced'' texts.
+</fragment>
+
+<fragment>
+Of course you can **__//''combine''//__** all these. 8-)
+</fragment>
+
+<fragment>
+You can use <sub>subscript</sub> and <sup>superscript</sup>, too.
+</fragment>
+
+<fragment>
+You can mark something as <del>deleted</del> as well.
+</fragment>
+
+
+
+==== Fragment Block ====
+
+With <nowiki><fragment-block></nowiki> you have more or less no limits:
+
+
+<fragment-block 2>
+{{:wiki:dokuwiki-128.png?nolink|}}\\
+This comes second :-)\\
+<nowiki><fragment-block 2></nowiki>
+</fragment-block>
+
+<fragment-block 1>
+<code php>
+$number = intval($test); //this comes first :-)
+</code>
+<nowiki><fragment-block 1></nowiki>
+</fragment-block>
+
+
+
+==== Fragment List ====
+
+<nowiki><fragment-list></nowiki> overwrites the global option build_all_lists:
+
+<fragment-list>
+  * List item 1
+  * List item 2
+  * List item 3
+</fragment-list>
+
+
+
+==== No Fragment List ====
+
+<nowiki><no-fragment-list></nowiki> overwrites also the global option build_all_lists:
+
+<no-fragment-list>
+  * List item 1
+  * List item 2
+  * List item 3
+</no-fragment-list>
+
+
+
+==== Fragment Styles ====
+
+Fragments can be styled: <nowiki><fragment StyleName></nowiki>
+
+<fragment grow>grow</fragment>
+
+<fragment shrink>shrink</fragment>
+
+<fragment fade-out>fade-out</fragment>
+
+<fragment fade-up>fade-up (also down, left and right!)</fragment>
+
+<fragment current-visible>current-visible</fragment>
+
+<fragment highlight-current-red>highlight-current-red (blue, green)</fragment>
+
+Highlight <fragment highlight-red>red</fragment> <fragment highlight-blue>blue</fragment> <fragment highlight-green>green</fragment>
+
+
+
 {{background>#000000}}
 ===== Background =====
 
 This slide has black background.
+
+
+
+===== Quotes =====
+
+This is the original example from the DokuWiki syntax description. For Reveal we suppress the nesting, because the quotes are shown in a different way:
+
+I think we should do it
+
+> No we shouldn't
+
+>> Well, I say we should
+
+> Really?
+
+>> Yes!
+
+>>> Then lets do it!
+
 
 
 ===== MathJax =====
@@ -41,6 +181,7 @@ Display math
 \[
 \int f dx
 \]
+
 
 
 ===== Code  =====
@@ -137,6 +278,17 @@ small block small block small block
 </WRAP>
 
 
+==== Small Fonts & Fragments ====
+
+Normal size and <fragment><wrap lo>small size</wrap></fragment>
+
+normal normal normal
+
+<WRAP lo>
+small block small block <fragment highlight-red>small block</fragment>
+</WRAP>
+
+
 ===== Links =====
 
 Interwiki link [[wiki:maintenance:djvu_support]]
@@ -144,12 +296,16 @@ Interwiki link [[wiki:maintenance:djvu_support]]
 WWW link www.google.de
 
 
+
 {{background>wiki:dokuwiki-128.png}}
 ====== H1 With Background ======
-with background
 
 
-===== Without Background 1 =====
 
+==== Without Background 1 ====
+
+Test, if background is not applied to nested slides
 
 ===== Without Background 2 =====
+
+Test, if background is not applied to the next slide

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -15,3 +15,4 @@ $lang['show_progress_bar'] = "Show the progress bar";
 $lang['open_in_new_window'] = "Open a presentation in a new window or tab";
 $lang['slide_level'] = "Headers on this level or above starting a horizontal slide. Levels below starting a vertical (nested) slide";
 $lang['push_headers'] = "Push headers below slide_level to the next higher one";
+$lang['image_borders'] = "Show image borders (default in Reveal.js)";

--- a/syntax/footer.php
+++ b/syntax/footer.php
@@ -23,7 +23,7 @@ class syntax_plugin_revealjs_footer extends DokuWiki_Syntax_Plugin {
      * @public
      * @see render()
      */
-    function connectTo($mode) {
+    public function connectTo($mode) {
         $this->Lexer->addSpecialPattern('{{no-footer}}', $mode, 'plugin_revealjs_footer');
     }
 

--- a/syntax/fragment.php
+++ b/syntax/fragment.php
@@ -1,0 +1,111 @@
+<?php
+
+if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_revealjs_fragment extends DokuWiki_Syntax_Plugin {
+
+    public function getType() { return 'substition'; }
+    public function getAllowedTypes() { return array('formatting', 'substition', 'disabled'); }
+    public function getSort() { return 33; } // must be after fragment_block, otherwise to much matches
+
+
+    /**
+     * Connect lookup pattern to lexer.
+     *
+     * @param $aMode String The desired rendermode.
+     * @return none
+     * @public
+     * @see render()
+     */
+    public function connectTo($mode) {
+        $this->Lexer->addEntryPattern('<fragment\b.*?>(?=[\s\S]*?<\/fragment>)', $mode, 'plugin_revealjs_fragment');
+    }
+    public function postConnect() { $this->Lexer->addExitPattern('<\/fragment>','plugin_revealjs_fragment'); }
+
+
+    /**
+     * Handler to prepare matched data for the rendering process.
+     *
+     * @param $aMatch String The text matched by the patterns.
+     * @param $aState Integer The lexer state for the match.
+     * @param $aPos Integer The character position of the matched text.
+     * @param $aHandler Object Reference to the Doku_Handler object.
+     * @return Integer The current lexer state for the match.
+     * @public
+     * @see render()
+     * @static
+     */
+     public function handle($match, $state, $pos, Doku_Handler $handler) {
+         switch ($state) {
+            case DOKU_LEXER_ENTER :
+                list($type, $param1, $param2) = preg_split("/\s+/", substr($match, 1, -1), 3);
+                if ($param1) {
+                    if ($this->_is_valid_style($param1)) $style = $param1;
+                    elseif (intval($param1) > 0) $index = $param1;
+                }
+                if ($param2) {
+                    if (intval($param2) > 0) $index = $param2;
+                    elseif ($this->_is_valid_style($param2)) $style = $param2;
+                }
+                return array($state, array($style, $index));
+
+           case DOKU_LEXER_UNMATCHED :  return array($state, $match);
+           case DOKU_LEXER_EXIT :       return array($state, '');
+         }
+     }
+
+
+    /**
+     * Handle the actual output creation.
+     *
+     * @param $aFormat String The output format to generate.
+     * @param $aRenderer Object A reference to the renderer object.
+     * @param $aData Array The data created by the <tt>handle()</tt>
+     * method.
+     * @return Boolean <tt>TRUE</tt> if rendered successfully, or
+     * <tt>FALSE</tt> otherwise.
+     * @public
+     * @see handle()
+     */
+    public function render($mode, Doku_Renderer $renderer, $data) {
+        if($mode == 'xhtml') {
+            list($state, $match) = $data;
+            switch ($state) {
+                case DOKU_LEXER_ENTER :
+                    if (is_a($renderer, 'renderer_plugin_revealjs')){
+                        list($style, $index) = $match;
+                        $renderer->doc .= '<span class="fragment' . ($style ? ' '.$style : '') . '"' .
+                            ($index ? ' data-fragment-index="'.$index.'"' : '') . '>';
+                    }
+                    break;
+                case DOKU_LEXER_UNMATCHED :
+                    $renderer->doc .= $renderer->_xmlEntities($match);
+                    break;
+                case DOKU_LEXER_EXIT :
+                    if (is_a($renderer, 'renderer_plugin_revealjs')){
+                        $renderer->doc .= '</span>';
+                    }
+                    break;
+            }
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Validate fragment style: $style
+     */
+    private function _is_valid_style($style) {
+        $pattern = '/grow|shrink|fade-(?:in|out|up|down|left|right)|current-visible|highlight(?:-current)?-(?:red|green|blue)/';
+        if (preg_match($pattern, $style)) return $style;
+        return '';
+    }
+
+}

--- a/syntax/fragmentblock.php
+++ b/syntax/fragmentblock.php
@@ -1,0 +1,110 @@
+<?php
+
+if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_revealjs_fragmentblock extends DokuWiki_Syntax_Plugin {
+
+    public function getType() { return 'substition'; }
+    public function getSort() { return 32; }
+    public function getPType() { return 'block'; }
+
+
+    /**
+     * Connect lookup pattern to lexer.
+     *
+     * @param $aMode String The desired rendermode.
+     * @return none
+     * @public
+     * @see render()
+     */
+    public function connectTo($mode) {
+        $this->Lexer->addSpecialPattern('<\/?(?:no-)?fragment-(?:block|list)\b.*?>', $mode, 'plugin_revealjs_fragmentblock');
+    }
+
+
+    /**
+     * Handler to prepare matched data for the rendering process.
+     *
+     * @param $aMatch String The text matched by the patterns.
+     * @param $aState Integer The lexer state for the match.
+     * @param $aPos Integer The character position of the matched text.
+     * @param $aHandler Object Reference to the Doku_Handler object.
+     * @return Integer The current lexer state for the match.
+     * @public
+     * @see render()
+     * @static
+     */
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
+        list($type, $param1, $param2) = preg_split("/\s+/", substr($match, 1, -1), 3);
+        if ($param1) {
+            if ($this->_is_valid_style($param1)) $style = $param1;
+            elseif (intval($param1) > 0) $index = $param1;
+        }
+        if ($param2) {
+            if (intval($param2) > 0) $index = $param2;
+            elseif ($this->_is_valid_style($param2)) $style = $param2;
+        }
+        return array($type, $style, $index);
+    }
+
+
+    /**
+     * Handle the actual output creation.
+     *
+     * @param $aFormat String The output format to generate.
+     * @param $aRenderer Object A reference to the renderer object.
+     * @param $aData Array The data created by the <tt>handle()</tt>
+     * method.
+     * @return Boolean <tt>TRUE</tt> if rendered successfully, or
+     * <tt>FALSE</tt> otherwise.
+     * @public
+     * @see handle()
+     */
+    public function render($mode, Doku_Renderer $renderer, $data) {
+        if($mode == 'xhtml' && is_a($renderer, 'renderer_plugin_revealjs')) {
+            list($type, $style, $index) = $data;
+            switch ($type) {
+                case 'fragment-block' :
+                    $renderer->doc .= DOKU_LF.'<div class="fragment' . ($style ? ' '.$style : '') . '"' .
+                        ($index ? ' data-fragment-index="'.$index.'"' : '') . '>';
+                    break;
+                case '/fragment-block' :
+                    $renderer->doc .= '</div>'.DOKU_LF;
+                    break;
+                case 'fragment-list' :
+                    $renderer->fragment_list_open = true;
+                    $renderer->fragment_style = $style;
+                    break;
+                case '/fragment-list' :
+                    $renderer->fragment_list_open = false;
+                    $renderer->fragment_style = '';
+                    break;
+                case 'no-fragment-list' :
+                    $renderer->no_fragment_list_open = true;
+                    break;
+                case '/no-fragment-list' :
+                    $renderer->no_fragment_list_open = false;
+                    break;
+            }
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Validate fragment style: $style
+     */
+    private function _is_valid_style($style) {
+        $pattern = '/grow|shrink|fade-(?:in|out|up|down|left|right)|current-visible|highlight(?:-current)?-(?:red|green|blue)/';
+        if (preg_match($pattern, $style)) return $style;
+        return '';
+    }
+
+}

--- a/syntax/theme.php
+++ b/syntax/theme.php
@@ -23,7 +23,7 @@ class syntax_plugin_revealjs_theme extends DokuWiki_Syntax_Plugin {
      * @public
      * @see render()
      */
-    function connectTo($mode) {
+    public function connectTo($mode) {
          $this->Lexer->addSpecialPattern('~~REVEAL[^~]*~~',$mode,'plugin_revealjs_theme');
     }
 


### PR DESCRIPTION
## Changes overview
- Introducing new syntax for speaker notes - https://github.com/hakimel/reveal.js#speaker-notes
  - <notes> - no parameters
  - No changes on wiki pages
  - On slideshow content is wrapped into <div class="notes">
  - Lists in notes are always NOT incremental, because the list is unvisible and you would have to press the next key for each entry without any obvious effect
- Introducing new syntax for fragments - https://github.com/hakimel/reveal.js#fragments
  - <fragment> for inline usage (only formatting and substitutions supported)
  - <fragment-block> for any wiki content
  - <fragment-list> to overwrite the global option build_all_lists (if false)
  - <no-fragment-list> to overwrite the global option build_all_lists (if true)
  - support for style and index where possible - see also example_presentation.dokuwiki and http://lab.hakim.se/reveal-js/#/7/1
- Improved blockquote handling
  - The nesting is suppressed on the slideshow to support the way Reveal is showing notes
- Improved DokuWiki text formatting on the slides
  - underlined text is now underlined and no longer italic
  - Subscript and superscript are now a bit smaller than the default text
- New conf option for image borders
  - In DokuWiki in the default theme images have no borders
  - In Reveal the images have borders
  - Now you can configure this globally in the plugin settings and since all options are overwritable per wiki page you can have different settings on different pages
